### PR TITLE
Enables channel filtering

### DIFF
--- a/broadcaster.py
+++ b/broadcaster.py
@@ -29,6 +29,7 @@ REDIS_DB = int(os.getenv("REDIS_DB", 0))
 REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", None)
 REDIS_TTL = int(os.getenv("REDIS_TTL", 60))
 REDIS_SAMPLE_RATE = int(os.getenv("REDIS_SAMPLE_RATE", 8)) # 1/8 images will be post to redis
+REDIS_FILTER_CHANNEL = os.getenv("REDIS_FILTER_CHANNEL", None) # Regex to filter channels
 redis_hosts = requests.get(REDIS_HOST_LIST_URL).json() if REDIS_HOST_LIST_URL else [REDIS_HOST]
 
 WORKERS = int(os.getenv("WORKERS", multiprocessing.cpu_count()))
@@ -94,6 +95,9 @@ def post_http_to_host(channel, data, path, host):
 
 @log_on_error
 def post_redis(channel, data, path):
+    if REDIS_FILTER_CHANNEL and not re.compile(REDIS_FILTER_CHANNEL).match(channel):
+        return
+
     digits = re.findall("(\d+)", path)
     if digits:
         count = int(digits[-1]) % REDIS_SAMPLE_RATE

--- a/broadcaster.py
+++ b/broadcaster.py
@@ -20,6 +20,7 @@ HTTP_HOST_LIST_URL = os.getenv("HTTP_HOST_LIST_URL", None)
 HTTP_HOST = os.getenv("HTTP_HOST", "localhost")
 HTTP_PORT = int(os.getenv("HTTP_PORT", 9080))
 HTTP_PUBLISH_URL_TEMPLATE = os.getenv("HTTP_PUBLISH_URLS_TEMPLATE", 'http://{host}:{port}/pub?id={channel}')
+HTTP_FILTER_CHANNEL = os.getenv("HTTP_FILTER_CHANNEL", None) # Regex to filter channels
 http_hosts = requests.get(HTTP_HOST_LIST_URL).json() if HTTP_HOST_LIST_URL else [HTTP_HOST]
 
 REDIS_HOST_LIST_URL = os.getenv("REDIS_HOST_LIST_URL", None)
@@ -79,6 +80,8 @@ def post(path):
 
 @log_on_error
 def post_http(channel, data, path):
+    if HTTP_FILTER_CHANNEL and not re.compile(HTTP_FILTER_CHANNEL).match(channel):
+        return
     for host in [h for h in http_hosts if h]:
         post_http_to_host(channel, data, path, host)
 


### PR DESCRIPTION
Very often you might need to save cpu resources by limiting the broadcaster to send data to only a selected set of channels. 

This will enable filtering channels for redis and pushstream by using regex, you can config them with environment variable. 

`HTTP_FILTER_CHANNEL` and `REDIS_FILTER_CHANNEL`

You can see some usage on integration test file.